### PR TITLE
Skip importing AWS Service linked Roles

### DIFF
--- a/lib/logic/role_registerer.js
+++ b/lib/logic/role_registerer.js
@@ -1,148 +1,144 @@
-'use strict';
+'use strict'
 
-const iam = require('../aws/iam');
-const iamRole = require('../aws/role');
-const attach = require('../aws/attach');
-const Result = require('../utils/result');
+const iam = require('../aws/iam')
+const iamRole = require('../aws/role')
+const attach = require('../aws/attach')
+const Result = require('../utils/result')
 
 
 class RoleRegisterer {
-  constructor(opts) {
-    const opts_ = opts || {};
-    this._overwrite = opts_['overwrite'] || false;
+  constructor(opts = {}) {
+    this._overwrite = opts['overwrite'] || false
   }
 
-  register(name, document) {
+  async register(name, document) {
     try {
-      const results = [];
-      const roleName = document.Role.RoleName;
-
-      return this._createRole(document, results)
-      .then(createdRole => {
-        if (!createdRole) return; // already exists
-        if (!iamRole.isEc2Role(document.Role)) return;
-
-        return this._createInstanceProfile(roleName, results)
-        .then(result => {
-          if (result !== null) {
-            return this._addRoleToInstanceProfile(roleName, roleName, results);
-          }
-        });
-      })
-      .then(() => this._getRolePolicies(document))
-      .then(result => {
-        return Promise.all([].concat(
-          result.attaching.map(entry => this._attachRolePolicy(entry)),
-          result.detaching.map(entry => this._detachRolePolicy(entry)),
-          result.unchanged.map(entry => {
-            const policyName = onlyPolicyName(entry.PolicyArn);
-            return Result.Skip('Policy: %1 is already attached on Role: %2', [policyName, entry.RoleName]);
-          })
-        ));
-      })
-      .then(attachResults => {
-        return results.concat(attachResults);
-      });
+      const results = []
+      await this._createRoleOrWithInstanceProfile(document, results)
+      const rolePolicies = await this._getRolePolicies(document)
+      const attachResults = await Promise.all([].concat(
+        rolePolicies.attaching.map(entry => this._attachRolePolicy(entry)),
+        rolePolicies.detaching.map(entry => this._detachRolePolicy(entry)),
+        rolePolicies.unchanged.map(entry => {
+          const policyName = onlyPolicyName(entry.PolicyArn)
+          return Result.Skip('Policy: %1 is already attached on Role: %2', [policyName, entry.RoleName])
+        })
+      ))
+      return results.concat(attachResults)
     } catch(err) {
-      const r = Result.NG('Failed to create Role: %1 invalid JSON format', name);
-      return Promise.resolve(r);
+      return Result.NG('Failed to create Role: %1 invalid JSON format', name)
     }
   }
 
-  _createRole(entry, results) {
-    const roleName = entry.Role.RoleName;
-
-    return iamRole.createRole(entry.Role)
-    .then(role => {
-      results.push(Result.OK('Created Role: %1', roleName));
-      return entry.Role;
-    })
-    .catch(err => {
-      if (err.code === 'EntityAlreadyExists') {
-        results.push(Result.Skip('Role: %1 already exists.', roleName));
-        return null;
-      } else if (err.code === 'MalformedPolicyDocument') {
-        return Result.NG('Failed to create Role: %1 invalid JSON format', roleName);
+  async _createRoleOrWithInstanceProfile(document, results) {
+    const roleName = document.Role.RoleName
+    const createdRole = await this._createRole(document, results)
+    if (createdRole && iamRole.isEc2Role(document.Role)) {
+      const result = await this._createInstanceProfile(roleName, results)
+      if (result !== null) {
+        await this._addRoleToInstanceProfile(roleName, roleName, results)
       }
-      results.push(Result.NG('Failed to create Role: %1', roleName));
-      throw err;
-    });
+    }
+    return createdRole
   }
 
-  _createInstanceProfile(roleName, results) {
+  async _createRole(entry, results) {
+    const roleName = entry.Role.RoleName
+
+    if (entry.Role.Path.startsWith('/aws-service-role/')) {
+      results.push(Result.Skip('Role: %1 is AWS Service linked.', roleName))
+      return null
+    }
+
+    try {
+      const role = await iamRole.createRole(entry.Role)
+      results.push(Result.OK('Created Role: %1', roleName))
+      return entry.Role
+    } catch(err) {
+      if (err.code === 'EntityAlreadyExists') {
+        results.push(Result.Skip('Role: %1 already exists.', roleName))
+        return null
+      } else if (err.code === 'MalformedPolicyDocument') {
+        return Result.NG('Failed to create Role: %1 invalid JSON format', roleName)
+      }
+      results.push(Result.NG('Failed to create Role: %1', roleName))
+      throw err
+    }
+  }
+
+  async _createInstanceProfile(roleName, results) {
     const params = {
       InstanceProfileName: roleName
-    };
+    }
 
-    return iam.createInstanceProfile(params).promise()
-    .then(data => {
-      results.push(Result.OK('Created InstanceProfile: %1', roleName));
-      return data.InstanceProfile;
-    })
-    .catch(err => {
+    try {
+      const data = await iam.createInstanceProfile(params).promise()
+      results.push(Result.OK('Created InstanceProfile: %1', roleName))
+      return data.InstanceProfile
+    } catch(err) {
       if (err.code === 'EntityAlreadyExists') {
-        results.push(Result.Skip('InstanceProfile: %1 already exists.', roleName));
-        return null;
+        results.push(Result.Skip('InstanceProfile: %1 already exists.', roleName))
+        return null
       }
-      results.push(Result.NG('Failed to create InstanceProfile: %1', roleName));
-      throw err;
-    });
+      results.push(Result.NG('Failed to create InstanceProfile: %1', roleName))
+      throw err
+    }
   }
 
-  _addRoleToInstanceProfile(profileName, roleName, results) {
+  async _addRoleToInstanceProfile(profileName, roleName, results) {
     const params = {
       InstanceProfileName: profileName,
       RoleName: roleName
-    };
+    }
 
-    return iam.addRoleToInstanceProfile(params).promise()
-    .then(data => {
-      results.push(Result.OK('Added InstanceProfile: %1 to Role: %2', [profileName, roleName]));
-    })
-    /*.catch(err => {
-      if (err.code === 'LimitExceeded') {
-        console.log(Status.Skip, err.message);
-        return;
-      }
-      throw err;
-    })*/;
+    try {
+      iam.addRoleToInstanceProfile(params).promise()
+      results.push(Result.OK('Added InstanceProfile: %1 to Role: %2', [profileName, roleName]))
+    } catch(err) {
+      /*if (err.code === 'LimitExceeded') {
+        console.log(Status.Skip, err.message)
+        return
+      }*/
+      throw err
+    }
   }
 
-  _getRolePolicies(role) {
-    const roleName = role.Role.RoleName;
+  async _getRolePolicies(role) {
+    const roleName = role.Role.RoleName
     const policyList = role.AttachedPolicies.map(item => {
       return {
         RoleName: roleName,
         PolicyArn: item.PolicyArn,
-      };
-    });
-
-    return attach.diffAttachedPolicies(roleName, policyList);
-  }
-
-  _attachRolePolicy(params) {
-    const policyName = onlyPolicyName(params.PolicyArn);
-
-    return iam.attachRolePolicy(params).promise()
-    .then(data => Result.OK('Attached %1 on %2', [policyName, params.RoleName]))
-    .catch(err => {
-      if (err.code === 'NoSuchEntity') {
-        return Result.NG('Could not attach Policy: %1 that does not exist on %2.', [policyName, params.RoleName]);
       }
-      throw err;
-    });
+    })
+
+    return attach.diffAttachedPolicies(roleName, policyList)
   }
 
-  _detachRolePolicy(params) {
-    const policyName = onlyPolicyName(params.PolicyArn);
+  async _attachRolePolicy(params) {
+    const policyName = onlyPolicyName(params.PolicyArn)
 
-    return iam.detachRolePolicy(params).promise()
-    .then(data => Result.OK('Detached %1 on %2', [policyName, params.RoleName]));
+    try {
+      await iam.attachRolePolicy(params).promise()
+      return Result.OK('Attached %1 on %2', [policyName, params.RoleName])
+    } catch(err) {
+      if (err.code === 'NoSuchEntity') {
+        return Result.NG('Could not attach Policy: %1 that does not exist on %2.', [policyName, params.RoleName])
+      }
+      throw err
+    }
+  }
+
+  async _detachRolePolicy(params) {
+    const policyName = onlyPolicyName(params.PolicyArn)
+
+    await iam.detachRolePolicy(params).promise()
+    Result.OK('Detached %1 on %2', [policyName, params.RoleName])
   }
 }
 
 module.exports = RoleRegisterer;
 
 function onlyPolicyName(policyArn) {
-  return policyArn.substr(policyArn.indexOf('/') + 1);
+  return policyArn.substr(policyArn.indexOf('/') + 1)
 }


### PR DESCRIPTION
```
{ InvalidInput: Path prefix '/aws-service-role/' can only be used for AWS Service linked Roles
    at Request.extractError (/home/toshi/work/me/aws-iam-policy-tool/node_modules/aws-sdk/lib/protocol/query.js:50:29)
    at Request.callListeners (/home/toshi/work/me/aws-iam-policy-tool/node_modules/aws-sdk/lib/sequential_executor.js:106:20)
    at Request.emit (/home/toshi/work/me/aws-iam-policy-tool/node_modules/aws-sdk/lib/sequential_executor.js:78:10)
    at Request.emit (/home/toshi/work/me/aws-iam-policy-tool/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/home/toshi/work/me/aws-iam-policy-tool/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/home/toshi/work/me/aws-iam-policy-tool/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /home/toshi/work/me/aws-iam-policy-tool/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/home/toshi/work/me/aws-iam-policy-tool/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/home/toshi/work/me/aws-iam-policy-tool/node_modules/aws-sdk/lib/request.js:685:12)
    at Request.callListeners (/home/toshi/work/me/aws-iam-policy-tool/node_modules/aws-sdk/lib/sequential_executor.js:116:18)
  message:
   "Path prefix '/aws-service-role/' can only be used for AWS Service linked Roles",
```